### PR TITLE
いよいよlogbackで遊んでみる

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ IntelliJ だと ~~(なぜか)~~ 打ち消し線が引かれるので「回避方
 + import scala.jdk.CollectionConverters._
 ```
 
+### Jackson-module との関係
+
+`logstash-logback-encoder` は内部実装に `Jackson` を使っている。
+なので、ログに追加する値は `Jackson` でエンコードできる型である必要がある。
+
+→ `Map(...).asJava` しているのはそのため
+
+```scala
+// StructuredArgument で動的にフィールドを追加
+import net.logstash.logback.argument.StructuredArguments._
+logger.info("StructuredArguments.value {}", value("KEY", "VALUE"))       // 単一の値を追加する
+logger.info("StructuredArguments.keyValue {}", keyValue("KEY", "VALUE")) // 単一の値を追加する
+logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava)) // 複数の値を追加する
+logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))   // 複数の値を追加する
+logger.info("StructuredArguments.raw {}", raw("raw", """{"KEY":"VALUE"}""")) // Raw な JSON で追加する
+```
+
 ### 疑問
 
 - `extends App` がついていると、`scalatest` から呼び出してもログが出力されない..??

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scala-playground
 
-## logback (logstash-logback-encoder の勉強)
+## `feature/logstash-logback-encoder-study` logback (logstash-logback-encoder の勉強)
 
 依存関係
 
@@ -68,7 +68,9 @@ IntelliJ だと ~~(なぜか)~~ 打ち消し線が引かれるので「回避方
 - test で実行する場合も `src/test/resources/logback-test.xml` は必須ではないみたい
   - この場合も `src/main/resources/logback.xml` を読んでくれているのかな？
 
-## jackson-module-scala の勉強
+---
+
+## `feature/jackson-module-study` jackson-module-scala の勉強
 
 教材: https://kazuhira-r.hatenablog.com/entry/20140419/1397899036
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))   // 
 logger.info("StructuredArguments.raw {}", raw("raw", """{"KEY":"VALUE"}""")) // Raw な JSON で追加する
 ```
 
+### MDC
+
+https://www.slf4j.org/api/org/slf4j/MDC.html
+
+- [logback+MDCでWebアプリのリクエスト内容を簡単にログに出力する方法](https://qiita.com/namutaka/items/c35c437b7246c5e4d729)
+- [[Java] MDC.putはstatic呼び出しなのにスレッドごとの情報を持てるヒミツ - ThreadLocal](https://zenn.dev/yucatio/articles/24bfaf9ed831a1)
+
+
+> 複数クライアントからの同時アクセス時のログ出力のパターンとしてMDCが考案されました
+
+> ポピュラーなログ出力ライブラリである、log4j2、logback等はMDCを実装しています 
+
+
+- [slf4jで独自ログ項目を追加(MDC)](https://www.nextdoorwith.info/wp/se/slf4j-custom-item-mdc/)
+
 ### 疑問
 
 - `extends App` がついていると、`scalatest` から呼び出してもログが出力されない..??

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))   // 
 logger.info("StructuredArguments.raw {}", raw("raw", """{"KEY":"VALUE"}""")) // Raw な JSON で追加する
 ```
 
+**`jackson-module` を使った logging**
+
+> `jackson-module-scala` は `Scala` 向けの `Jackson` モジュールです。
+> `Scala` のコレクションや `case class` をJSONにマッピング可能になります。
+
+> `logstash-logback-encoder` はクラスパスに存在する `Jackson` のモジュールを自動的に取得し、マッピングに登録してくれます。
+> なので、依存関係を追加するだけでコードを変更する必要はありません!
+>
+> (この動作はバージョン `5.3` でサポートされた動作です。それ以前のバージョンは手動で追加する必要があります。)
+
+へぇ〜、`import なんちゃら.auto._` みたいなのしなくても、インストールされていれば、自動でパースされるんだ〜。すご〜
+
 ### MDC
 
 https://www.slf4j.org/api/org/slf4j/MDC.html

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ libraryDependencies ++= Seq(
 
 [logbackの設定](https://xy2401.com/local-docs/java/logback/manual/configuration_ja.html)
 
+### 実行方法
+
+```bash
+$ sbt
+sbt:jackson-module-sample> testOnly com.github.sudachi0114.logexample.LogExampleSpec
+```
+
+### 疑問
+
+- `extends App` がついていると、`scalatest` から呼び出してもログが出力されない..??
+- test で実行する場合も `src/test/resources/logback-test.xml` は必須ではないみたい
+  - この場合も `src/main/resources/logback.xml` を読んでくれているのかな？
+
 ## jackson-module-scala の勉強
 
 教材: https://kazuhira-r.hatenablog.com/entry/20140419/1397899036

--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ $ sbt
 sbt:logback-study> testOnly com.github.sudachi0114.logexample.LogExampleSpec
 ```
 
+### asJava
+
+```scala
+import scala.collection.JavaConverters._
+logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava)) // 複数の値を追加する
+```
+
+> `logstash-logback-encoder` は内部実装に `Jackson` を使っているので、ログに追加する値は `Jackson` でエンコードできる型である必要があります。
+> ( `Map(...).asJava` しているのはそのためです。これを回避する方法は後述します。)
+
+とのこと。`.asJava` 使うには `scala.collection.JavaConverters._` のインポートが必要だった
+
+IntelliJ だと (なぜか) 打ち消し線が引かれるので「回避方法」を後でやる。
+
+[JavaConverters - Scala Javaコレクション変換](http://www.ne.jp/asahi/hishidama/home/tech/scala/collection/javaconv.html)
+
 ### 疑問
 
 - `extends App` がついていると、`scalatest` から呼び出してもログが出力されない..??

--- a/README.md
+++ b/README.md
@@ -47,9 +47,20 @@ logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> 
 
 とのこと。`.asJava` 使うには `scala.collection.JavaConverters._` のインポートが必要だった
 
-IntelliJ だと (なぜか) 打ち消し線が引かれるので「回避方法」を後でやる。
+IntelliJ だと ~~(なぜか)~~ 打ち消し線が引かれるので「回避方法」を後でやる。
 
 [JavaConverters - Scala Javaコレクション変換](http://www.ne.jp/asahi/hishidama/home/tech/scala/collection/javaconv.html)
+
+```log
+[warn] ../scala-playground/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala:14:60: object JavaConverters in package collection is deprecated (since 2.13.0): Use `scala.jdk.CollectionConverters` instead
+```
+
+コンパイル時のログ出力に答えがあった
+
+```diff
+- import scala.collection.JavaConverters._
++ import scala.jdk.CollectionConverters._
+```
 
 ### 疑問
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ logger.info("StructuredArguments.raw {}", raw("raw", """{"KEY":"VALUE"}""")) // 
 
 へぇ〜、`import なんちゃら.auto._` みたいなのしなくても、インストールされていれば、自動でパースされるんだ〜。すご〜
 
+* 実行方法
+
+```bash
+$ sbt
+sbt:logback-study> testOnly com.github.sudachi0114.logexample.CaseClassLoggingSpec
+```
+
 ### MDC
 
 https://www.slf4j.org/api/org/slf4j/MDC.html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # scala-playground
 
+## logback (logstash-logback-encoder の勉強)
+
+依存関係
+
+```sbt
+libraryDependencies ++= Seq(
+  "ch.qos.logback" % "logback-classic" % "1.2.3",  // logstash-logback-encoder はlogbackに直接依存していないので、logback-classic を追加
+  "net.logstash.logback" % "logstash-logback-encoder" % "5.3",
+)
+```
+
+### logback の設定ファイル
+
+`logback.xml` は `src/main/resources` 下に配置する。
+より正確には、クラスパス内に配置すれば、自動的に読んでくれるらしい。
+(クラスパス内ってどこ？)
+
+[全体の構成 - Slf4j+logbackの基本的な設定と使い方](https://tech.chakapoko.com/java/logging/slf4j-logback-basic.html)
+
+**設定ファイルを探す順番**
+
+1. logback はクラスパス上で `logback.groovy` というファイルを探します
+2. 見つからなかったら、今度はクラスパス上で `logback-test.xml` というファイルを探します
+3. 見つからなかったら、今度はクラスパス上で `logback.xml` というファイルを探します
+4. 何も見つからなかったら、自動的に `BasicConfigurator` を使って設定します。ロギング出力は直接コンソールに出力されるようになります
+
+[logbackの設定](https://xy2401.com/local-docs/java/logback/manual/configuration_ja.html)
+
 ## jackson-module-scala の勉強
 
 教材: https://kazuhira-r.hatenablog.com/entry/20140419/1397899036
@@ -135,9 +163,9 @@ $ sbt test
 ## 最終着地
 * logback の勉強がしたい
   - https://qiita.com/opengl-8080/items/49719f2d35171f017aa9
-  - https://labs.septeni.co.jp/entry/2019/03/07/120000
+  - https://labs.septeni.co.jp/entry/2019/03/07/120000 ← イマココ
     - ← jackson.module っていう、circe と似たようなライブラリがあるっぽい
-  - https://kazuhira-r.hatenablog.com/entry/20140419/1397899036 ← イマココ
+  - https://kazuhira-r.hatenablog.com/entry/20140419/1397899036
   - https://github.com/FasterXML/jackson-module-scala
     - ← scalatest を使っている 
     - ← scalatest 入らない.. ;; (IntelliJ との連携の問題だった)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
 
 ```bash
 $ sbt
-sbt:jackson-module-sample> testOnly com.github.sudachi0114.logexample.LogExampleSpec
+sbt:logback-study> testOnly com.github.sudachi0114.logexample.LogExampleSpec
 ```
 
 ### 疑問

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalaVersion := "2.13.8"
 
 // It's possible to define many kinds of settings, such as:
 
-name := "jackson-module-sample"
+name := "logback-study"
 organization := "com.github.sudachi0114"
 version := "0.0.1-SNAPSHOT"
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,8 @@ scalacOptions ++= Seq("-Xlint", "-deprecation", "-unchecked")
 // You can define other libraries as dependencies in your build like this:
 
 libraryDependencies ++= Seq(
+  "ch.qos.logback" % "logback-classic" % "1.2.3",  // logstash-logback-encoder はlogbackに直接依存していないので、logback-classic を追加
+  "net.logstash.logback" % "logstash-logback-encoder" % "5.3",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",
   "org.scalatest" %% "scalatest" % "3.2.11" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ scalacOptions ++= Seq("-Xlint", "-deprecation", "-unchecked")
 // You can define other libraries as dependencies in your build like this:
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.3",  // logstash-logback-encoder はlogbackに直接依存していないので、logback-classic を追加
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
   "net.logstash.logback" % "logstash-logback-encoder" % "5.3",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",
   "org.scalatest" %% "scalatest" % "3.2.11" % Test

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+
+        <!-- JSON ログを出力する encoder -->
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <!-- Pretty Print -->
+            <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator" />
+        </encoder>
+
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,12 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-
         <!-- JSON ログを出力する encoder -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <!-- Pretty Print -->
-            <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator" />
-        </encoder>
-
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
     <root level="DEBUG">

--- a/src/main/scala/com/github/sudachi0114/logexample/CaseClassLogging.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/CaseClassLogging.scala
@@ -1,0 +1,32 @@
+package com.github.sudachi0114.logexample
+
+import org.slf4j.LoggerFactory
+
+
+object CaseClassLogging {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  import net.logstash.logback.argument.StructuredArguments._
+  import scala.jdk.CollectionConverters._
+  logger.info("map in map", value(
+    "Scala map",
+    Map(
+      "map" -> Map(
+        "list" -> List(1, 2, 3).asJava
+      ).asJava
+    ).asJava
+  ))
+
+  case class User(id: Long, name: String, interests: List[String])
+
+  val user = User(100, "userA", List("Scala", "Logging"))
+
+  logger.info("case class logging", value(
+    "case class user",
+    Map(
+      "id" -> user.id,
+      "name" -> user.name,
+      "interests" -> user.interests.asJava
+    ).asJava
+  ))
+}

--- a/src/main/scala/com/github/sudachi0114/logexample/CaseClassLogging.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/CaseClassLogging.scala
@@ -18,6 +18,7 @@ object CaseClassLogging {
   ))
 
   case class User(id: Long, name: String, interests: List[String])
+  case class Group(value: Long, name: String, user: Set[User])
 
   val user = User(100, "userA", List("Scala", "Logging"))
 
@@ -29,4 +30,20 @@ object CaseClassLogging {
       "interests" -> user.interests.asJava
     ).asJava
   ))
+
+  // using jackson-module-scala
+  val group = Group(9000, "The Scala Group", Set(
+    User(100, "userA", List("Scala", "Logging")),
+    User(200, "userB", List("Java", "Kotlin"))
+  ))
+
+  val scalaMap = Map(
+    "KEY" -> "VALUE",
+    "map_in_map" -> Map(
+      "INNER_KEY" -> "INNER_VALUE"
+    ),
+    "group" -> group
+  )
+
+  logger.info("logging with Scala: {}", value("scala_map", scalaMap))
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -15,16 +15,6 @@ object LogExample {
   logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava))
   logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))
 
-  import net.logstash.logback.marker.Markers._
-  logger.info(append("KEY", "VALUE"), "Markers.append")
-  logger.info(appendEntries(Map("k1" -> "v1", "k2" -> "v2").asJava), "Markers.appendEntries")
-  logger.info(appendArray("array", "a", "b", "c"), "Markers.appendArray")
-  logger.info(appendRaw("raw", """{"KEY":"VALUE"}"""), "Markers.appendRaw")
-
-  // 複数の Markers を組み合わせることも可能
-  val marker : LogstashMarker = append("KEY_A", "VALUE_A").and(append("KEY_B", "VALUE_B"))
-  logger.info(marker, "multiple markers")
-
   import org.slf4j.MDC
   MDC.put("KEY", "VALUE")
   logger.info("logging with MDC")

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -1,0 +1,9 @@
+package com.github.sudachi0114.logexample
+
+import org.slf4j.LoggerFactory
+
+object LogExample extends App {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("Hello Logging with JSON!")
+}

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -38,4 +38,16 @@ object LogExample {
       ).asJava
     ).asJava
   ))
+
+  case class User(id: Long, name: String, interests: List[String])
+  val user = User(100, "userA", List("Scala", "Logging"))
+
+  logger.info("case class logging", value(
+    "case class user",
+    Map(
+      "id" -> user.id,
+      "name" -> user.name,
+      "interests" -> user.interests.asJava
+    ).asJava
+  ))
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -2,7 +2,7 @@ package com.github.sudachi0114.logexample
 
 import org.slf4j.LoggerFactory
 
-object LogExample extends App {
+object LogExample {
   val logger = LoggerFactory.getLogger(getClass)
 
   logger.info("Hello Logging with JSON!")

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -8,7 +8,7 @@ object LogExample {
   logger.info("Hello Logging with JSON!")
 
   import net.logstash.logback.argument.StructuredArguments._
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   logger.info("StructuredArguments.value {}", value("KEY", "VALUE"))       // 単一の値を追加する
   logger.info("StructuredArguments.keyValue {}", keyValue("KEY", "VALUE")) // 単一の値を追加する
   logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava)) // 複数の値を追加する

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -1,6 +1,5 @@
 package com.github.sudachi0114.logexample
 
-import net.logstash.logback.marker.LogstashMarker
 import org.slf4j.LoggerFactory
 
 object LogExample {
@@ -14,11 +13,6 @@ object LogExample {
   logger.info("StructuredArguments.keyValue {}", keyValue("KEY", "VALUE"))
   logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava))
   logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))
-
-  import org.slf4j.MDC
-  MDC.put("KEY", "VALUE")
-  logger.info("logging with MDC")
-  MDC.remove("KEY")
 
   logger.info("map in map", value(
     "Scala map",

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -13,25 +13,4 @@ object LogExample {
   logger.info("StructuredArguments.keyValue {}", keyValue("KEY", "VALUE"))
   logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava))
   logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))
-
-  logger.info("map in map", value(
-    "Scala map",
-    Map(
-      "map" -> Map(
-        "list" -> List(1, 2, 3).asJava
-      ).asJava
-    ).asJava
-  ))
-
-  case class User(id: Long, name: String, interests: List[String])
-  val user = User(100, "userA", List("Scala", "Logging"))
-
-  logger.info("case class logging", value(
-    "case class user",
-    Map(
-      "id" -> user.id,
-      "name" -> user.name,
-      "interests" -> user.interests.asJava
-    ).asJava
-  ))
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -6,4 +6,12 @@ object LogExample {
   val logger = LoggerFactory.getLogger(getClass)
 
   logger.info("Hello Logging with JSON!")
+
+  import net.logstash.logback.argument.StructuredArguments._
+  import scala.collection.JavaConverters._
+  logger.info("StructuredArguments.value {}", value("KEY", "VALUE"))       // 単一の値を追加する
+  logger.info("StructuredArguments.keyValue {}", keyValue("KEY", "VALUE")) // 単一の値を追加する
+  logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava)) // 複数の値を追加する
+  logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))  // 複数の値を追加する
+  logger.info("StructuredArguments.raw {}", raw("raw", """{"KEY":"VALUE"}""")) // Raw な JSON で追加する
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -24,4 +24,9 @@ object LogExample {
   // 複数の Markers を組み合わせることも可能
   val marker : LogstashMarker = append("KEY_A", "VALUE_A").and(append("KEY_B", "VALUE_B"))
   logger.info(marker, "multiple markers")
+
+  import org.slf4j.MDC
+  MDC.put("KEY", "VALUE")
+  logger.info("logging with MDC")
+  MDC.remove("KEY")
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -9,9 +9,9 @@ object LogExample {
 
   import net.logstash.logback.argument.StructuredArguments._
   import scala.jdk.CollectionConverters._
-  logger.info("StructuredArguments.value {}", value("KEY", "VALUE"))       // 単一の値を追加する
-  logger.info("StructuredArguments.keyValue {}", keyValue("KEY", "VALUE")) // 単一の値を追加する
-  logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava)) // 複数の値を追加する
-  logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))  // 複数の値を追加する
-  logger.info("StructuredArguments.raw {}", raw("raw", """{"KEY":"VALUE"}""")) // Raw な JSON で追加する
+  logger.info("StructuredArguments.value {}", value("KEY", "VALUE"))
+  logger.info("StructuredArguments.keyValue {}", keyValue("KEY", "VALUE"))
+  logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava))
+  logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))
+
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -29,4 +29,13 @@ object LogExample {
   MDC.put("KEY", "VALUE")
   logger.info("logging with MDC")
   MDC.remove("KEY")
+
+  logger.info("map in map", value(
+    "Scala map",
+    Map(
+      "map" -> Map(
+        "list" -> List(1, 2, 3).asJava
+      ).asJava
+    ).asJava
+  ))
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/LogExample.scala
@@ -1,5 +1,6 @@
 package com.github.sudachi0114.logexample
 
+import net.logstash.logback.marker.LogstashMarker
 import org.slf4j.LoggerFactory
 
 object LogExample {
@@ -14,4 +15,13 @@ object LogExample {
   logger.info("StructuredArguments.entries {}", entries(Map("k1" -> "v1", "k2" -> "v2").asJava))
   logger.info("StructuredArguments.array {}", array("array", "a", "b", "c"))
 
+  import net.logstash.logback.marker.Markers._
+  logger.info(append("KEY", "VALUE"), "Markers.append")
+  logger.info(appendEntries(Map("k1" -> "v1", "k2" -> "v2").asJava), "Markers.appendEntries")
+  logger.info(appendArray("array", "a", "b", "c"), "Markers.appendArray")
+  logger.info(appendRaw("raw", """{"KEY":"VALUE"}"""), "Markers.appendRaw")
+
+  // 複数の Markers を組み合わせることも可能
+  val marker : LogstashMarker = append("KEY_A", "VALUE_A").and(append("KEY_B", "VALUE_B"))
+  logger.info(marker, "multiple markers")
 }

--- a/src/main/scala/com/github/sudachi0114/logexample/MDCLogging.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/MDCLogging.scala
@@ -1,0 +1,13 @@
+package com.github.sudachi0114.logexample
+
+import org.slf4j.LoggerFactory
+
+object MDCLogging {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  import org.slf4j.MDC
+
+  MDC.put("KEY", "VALUE")
+  logger.info("logging with MDC")
+  MDC.remove("KEY")
+}

--- a/src/main/scala/com/github/sudachi0114/logexample/MarkerLogging.scala
+++ b/src/main/scala/com/github/sudachi0114/logexample/MarkerLogging.scala
@@ -1,0 +1,18 @@
+package com.github.sudachi0114.logexample
+
+import com.github.sudachi0114.logexample.LogExample.logger
+import net.logstash.logback.marker.LogstashMarker
+
+object MarkerLogging {
+  import net.logstash.logback.marker.Markers._
+  import scala.jdk.CollectionConverters._
+  logger.info(append("KEY", "VALUE"), "Markers.append")
+  logger.info(appendEntries(Map("k1" -> "v1", "k2" -> "v2").asJava), "Markers.appendEntries")
+  logger.info(appendArray("array", "a", "b", "c"), "Markers.appendArray")
+  logger.info(appendRaw("raw", """{"KEY":"VALUE"}"""), "Markers.appendRaw")
+
+  // 複数の Markers を組み合わせることも可能
+  val marker : LogstashMarker = append("KEY_A", "VALUE_A").and(append("KEY_B", "VALUE_B"))
+  logger.info(marker, "multiple markers")
+
+}

--- a/src/main/scala/com/github/sudachi0114/simpletest/Main.scala
+++ b/src/main/scala/com/github/sudachi0114/simpletest/Main.scala
@@ -1,8 +1,12 @@
 package com.github.sudachi0114.simpletest
 
+import com.github.sudachi0114.logexample.LogExample
+
 object Main extends App {
   val p = new Person("sudachi")
   println(s"Hello ${p.name}")
+
+  LogExample
 }
 
 class Person(var name: String)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -4,6 +4,15 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <!-- Pretty Format -->
             <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
+
+            <!-- グローバルなカスタムフィールドを追加 -->
+            <customFields>
+                {
+                    "app_name": "logstash-logback-encoder-in-scala",
+                    "env": "staging"
+                }
+            </customFields>
+
         </encoder>
     </appender>
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- JSON ログを出力する encoder -->
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <!-- Pretty Format -->
+            <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/test/scala/com/github/sudachi0114/logexample/CaseClassLoggingSpec.scala
+++ b/src/test/scala/com/github/sudachi0114/logexample/CaseClassLoggingSpec.scala
@@ -1,0 +1,12 @@
+package com.github.sudachi0114.logexample
+
+import org.scalatest.funspec.AnyFunSpec
+
+class CaseClassLoggingSpec extends AnyFunSpec {
+  describe("logback case class test") {
+    it("should call CaseClassLogging") {
+      CaseClassLogging
+    }
+  }
+
+}

--- a/src/test/scala/com/github/sudachi0114/logexample/LogExampleSpec.scala
+++ b/src/test/scala/com/github/sudachi0114/logexample/LogExampleSpec.scala
@@ -1,6 +1,5 @@
 package com.github.sudachi0114.logexample
 
-import com.github.sudachi0114.logexample.LogExample
 import org.scalatest.funspec.AnyFunSpec
 
 class LogExampleSpec extends AnyFunSpec {

--- a/src/test/scala/com/github/sudachi0114/logexample/LogExampleSpec.scala
+++ b/src/test/scala/com/github/sudachi0114/logexample/LogExampleSpec.scala
@@ -1,0 +1,12 @@
+package com.github.sudachi0114.logexample
+
+import com.github.sudachi0114.logexample.LogExample
+import org.scalatest.funspec.AnyFunSpec
+
+class LogExampleSpec extends AnyFunSpec {
+  describe("logback test") {
+    it("should call LogExample") {
+      LogExample
+    }
+  }
+}

--- a/src/test/scala/com/github/sudachi0114/logexample/MDCLoggingSpec.scala
+++ b/src/test/scala/com/github/sudachi0114/logexample/MDCLoggingSpec.scala
@@ -1,0 +1,11 @@
+package com.github.sudachi0114.logexample
+
+import org.scalatest.funspec.AnyFunSpec
+
+object MDCLoggingSpec extends AnyFunSpec {
+  describe("logback MDC logging test") {
+    it("should call MDCLogging") {
+      MDCLogging
+    }
+  }
+}

--- a/src/test/scala/com/github/sudachi0114/logexample/MarkerLoggingSpec.scala
+++ b/src/test/scala/com/github/sudachi0114/logexample/MarkerLoggingSpec.scala
@@ -1,0 +1,11 @@
+package com.github.sudachi0114.logexample
+
+import org.scalatest.funspec.AnyFunSpec
+
+class MarkerLoggingSpec extends AnyFunSpec {
+  describe("logback MarkerLogging test") {
+    it("should call MarkerLogging") {
+      MarkerLogging
+    }
+  }
+}


### PR DESCRIPTION
# What, Why

- logback の勉強をする
  - 少ない依存関係でシンプルに学習する
  - 自分でゼロから作ってみて学ぶ (ここまで同じ)
  - どの言語でも、logging はおそらく基本的なデバッグの技能なので、素早く身に着ける

**残り**
- `jackson-module` の勉強をする
  - `circe` で書き直してもいいかもしれない

**次の予定**
- `akka http` と `logback` を組み合わせて使うお勉強
- `slick` とか `scalikeJDBC` とか、DB 周りのお勉強をする

- Scala プロダクトの docker 化とか、sbt と docker の整えとかもやりたいな〜
- gatling の勉強もしてえ〜
- あと php も勉強したいな〜

## 学んだこと

- logger の作り方：`org.slf4j.LoggerFactory` のインスタンスを作れば良い
- 関心ごとに class (ファイル) を分けると楽
  - それごとに `Spec` を作って `testOnly` で単体でテストを走らせると、よりいい感じ

# How
- `logexample` 以下に、さまざまな方法でログを出力するファイルを作成
  -  `XxxSpec` を作って、main で作った `Object` を指定して、実行
  - ログをとるだけなので、これの結果をみれば出力が見られる
- 参考文献などは READE に記載